### PR TITLE
Standardize tool names to lowercase and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 AI Tools for Unity ProBuilder. Let AI to work with ProBuilder features. Fast level prototyping. It is constructed on top of [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) platform.
 
+[![DOWNLOAD INSTALLER](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/button/button_download.svg?raw=true)](https://github.com/IvanMurzak/Unity-AI-ProBuilder/releases/download/1.0.2/AI-ProBuilder-Installer.unitypackage)
+
 ### Stability status
 
 | Unity Version | Editmode                                                                                                                                                                               | Playmode                                                                                                                                                                               | Standalone                                                                                                                                                                               |
@@ -28,25 +30,25 @@ AI Tools for Unity ProBuilder. Let AI to work with ProBuilder features. Fast lev
 ## AI ProBuilder Tools
 
 Core tools:
-- `ProBuilder_CreateShape` - Create primitive shapes (cube, sphere, cylinder, etc.)
-- `ProBuilder_GetMeshInfo` - Read mesh data (faces, vertices, edges)
-- `ProBuilder_Extrude` - Extrude faces with various methods
-- `ProBuilder_Bevel` - Bevel edges
-- `ProBuilder_DeleteFaces` - Delete faces by index or direction
-- `ProBuilder_SetFaceMaterial` - Apply materials to specific faces
+- `probuilder-create-shape` - Create primitive shapes (cube, sphere, cylinder, etc.)
+- `probuilder-get-mesh-info` - Read mesh data (faces, vertices, edges)
+- `probuilder-extrude` - Extrude faces with various methods
+- `probuilder-bevel` - Bevel edges
+- `probuilder-delete-faces` - Delete faces by index or direction
+- `probuilder-set-face-material` - Apply materials to specific faces
 
 Mesh operations:
-- `ProBuilder_FlipNormals` - Reverse face normals
-- `ProBuilder_SetPivot` - Change mesh pivot point
-- `ProBuilder_MergeObjects` - Combine multiple ProBuilder meshes
+- `probuilder-flip-normals` - Reverse face normals
+- `probuilder-set-pivot` - Change mesh pivot point
+- `probuilder-merge-objects` - Combine multiple ProBuilder meshes
 
 Edge operations:
-- `ProBuilder_SubdivideEdges` - Add vertices to edges
-- `ProBuilder_ConnectEdges` - Connect edges with new geometry
-- `ProBuilder_Bridge` - Bridge between edge selections
+- `probuilder-subdivide-edges` - Add vertices to edges
+- `probuilder-connect-edges` - Connect edges with new geometry
+- `probuilder-bridge` - Bridge between edge selections
 
 Advanced:
-- `ProBuilder_CreatePolyShape` - Create custom polygon-based meshes
+- `probuilder-create-poly-shape` - Create custom polygon-based meshes
 
 
 ## Installation

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_Bevel",
+            "probuilder-bevel",
             Title = "Bevel ProBuilder edges"
         )]
         [Description(@"Bevels selected edges of a ProBuilder mesh, creating chamfered corners.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_Bridge",
+            "probuilder-bridge",
             Title = "Bridge two edges in a ProBuilder mesh"
         )]
         [Description(@"Creates a new face connecting two edges.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_ConnectEdges",
+            "probuilder-connect-edges",
             Title = "Connect edges in a ProBuilder mesh"
         )]
         [Description(@"Inserts new edges connecting the midpoints of selected edges within faces.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_CreateShape",
+            "probuilder-create-shape",
             Title = "Create a ProBuilder shape"
         )]
         [Description(@"Creates a new ProBuilder mesh shape in the scene. ProBuilder shapes are editable 3D meshes

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_DeleteFaces",
+            "probuilder-delete-faces",
             Title = "Delete ProBuilder faces"
         )]
         [Description(@"Deletes selected faces from a ProBuilder mesh.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_Extrude",
+            "probuilder-extrude",
             Title = "Extrude ProBuilder faces"
         )]
         [Description(@"Extrudes selected faces of a ProBuilder mesh along their normals.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_FlipNormals",
+            "probuilder-flip-normals",
             Title = "Flip face normals in a ProBuilder mesh"
         )]
         [Description(@"Reverses the normal direction of selected faces, flipping them inside-out.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_GetMeshInfo",
+            "probuilder-get-mesh-info",
             Title = "Get ProBuilder mesh information"
         )]
         [Description(@"Retrieves information about a ProBuilder mesh including faces, vertices, and edges.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_MergeObjects",
+            "probuilder-merge-objects",
             Title = "Merge multiple ProBuilder meshes into one"
         )]
         [Description(@"Combines multiple ProBuilder meshes into a single mesh.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_CreatePolyShape",
+            "probuilder-create-poly-shape",
             Title = "Create a ProBuilder shape from polygon points"
         )]
         [Description(@"Creates a 3D mesh from a 2D polygon outline. Perfect for:

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_SetFaceMaterial",
+            "probuilder-set-face-material",
             Title = "Set material on ProBuilder faces"
         )]
         [Description(@"Assigns a material to specific faces of a ProBuilder mesh.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
@@ -41,7 +41,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_SetPivot",
+            "probuilder-set-pivot",
             Title = "Set the pivot point of a ProBuilder mesh"
         )]
         [Description(@"Changes the pivot (origin) point of a ProBuilder mesh.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "ProBuilder_SubdivideEdges",
+            "probuilder-subdivide-edges",
             Title = "Subdivide edges in a ProBuilder mesh"
         )]
         [Description(@"Inserts new vertices on edges, subdividing them into smaller segments.

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -15,7 +15,9 @@
 
 <img width="100%" alt="Stats" src="https://github.com/IvanMurzak/Unity-AI-ProBuilder/raw/main/docs/img/ai-probuilder-glitch.gif"/>
 
-AI Tools for Unity ProBuilder. Let AI to work with ProBuilder features. Fast level prototyping. It is constructed on top of [AI Game Developer](https://github.com/IvanMurzak/Unity-AI-ProBuilder) platform.
+AI Tools for Unity ProBuilder. Let AI to work with ProBuilder features. Fast level prototyping. It is constructed on top of [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) platform.
+
+[![DOWNLOAD INSTALLER](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/button/button_download.svg?raw=true)](https://github.com/IvanMurzak/Unity-AI-ProBuilder/releases/download/1.0.2/AI-ProBuilder-Installer.unitypackage)
 
 ### Stability status
 
@@ -28,25 +30,25 @@ AI Tools for Unity ProBuilder. Let AI to work with ProBuilder features. Fast lev
 ## AI ProBuilder Tools
 
 Core tools:
-- `ProBuilder_CreateShape` - Create primitive shapes (cube, sphere, cylinder, etc.)
-- `ProBuilder_GetMeshInfo` - Read mesh data (faces, vertices, edges)
-- `ProBuilder_Extrude` - Extrude faces with various methods
-- `ProBuilder_Bevel` - Bevel edges
-- `ProBuilder_DeleteFaces` - Delete faces by index or direction
-- `ProBuilder_SetFaceMaterial` - Apply materials to specific faces
+- `probuilder-create-shape` - Create primitive shapes (cube, sphere, cylinder, etc.)
+- `probuilder-get-mesh-info` - Read mesh data (faces, vertices, edges)
+- `probuilder-extrude` - Extrude faces with various methods
+- `probuilder-bevel` - Bevel edges
+- `probuilder-delete-faces` - Delete faces by index or direction
+- `probuilder-set-face-material` - Apply materials to specific faces
 
 Mesh operations:
-- `ProBuilder_FlipNormals` - Reverse face normals
-- `ProBuilder_SetPivot` - Change mesh pivot point
-- `ProBuilder_MergeObjects` - Combine multiple ProBuilder meshes
+- `probuilder-flip-normals` - Reverse face normals
+- `probuilder-set-pivot` - Change mesh pivot point
+- `probuilder-merge-objects` - Combine multiple ProBuilder meshes
 
 Edge operations:
-- `ProBuilder_SubdivideEdges` - Add vertices to edges
-- `ProBuilder_ConnectEdges` - Connect edges with new geometry
-- `ProBuilder_Bridge` - Bridge between edge selections
+- `probuilder-subdivide-edges` - Add vertices to edges
+- `probuilder-connect-edges` - Connect edges with new geometry
+- `probuilder-bridge` - Bridge between edge selections
 
 Advanced:
-- `ProBuilder_CreatePolyShape` - Create custom polygon-based meshes
+- `probuilder-create-poly-shape` - Create custom polygon-based meshes
 
 
 ## Installation


### PR DESCRIPTION
Standardize the naming convention of ProBuilder tools to lowercase for consistency. Update the README to include a download link for the installer.