### PR TITLE
chore: Update package dependencies and references in asmdef files

### DIFF
--- a/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.ProBuilder.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.ProBuilder.Editor.Tests.asmdef
@@ -4,10 +4,12 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "com.IvanMurzak.Unity.MCP.ProBuilder.Runtime",
-        "com.IvanMurzak.Unity.MCP.ProBuilder.Editor",
         "com.IvanMurzak.Unity.MCP.Editor",
-        "com.IvanMurzak.Unity.MCP.Runtime"
+        "com.IvanMurzak.Unity.MCP.Editor.Tests",
+        "com.IvanMurzak.Unity.MCP.Runtime",
+        "com.IvanMurzak.Unity.MCP.TestFiles",
+        "com.IvanMurzak.Unity.MCP.ProBuilder.Runtime",
+        "com.IvanMurzak.Unity.MCP.ProBuilder.Editor"
     ],
     "includePlatforms": [
         "Editor"
@@ -16,7 +18,15 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "System.Text.Json.dll",
+        "Microsoft.Extensions.Logging.Abstractions.dll",
+        "Microsoft.AspNetCore.SignalR.Client.dll",
+        "Microsoft.AspNetCore.SignalR.Client.Core.dll",
+        "ReflectorNet.dll",
+        "McpPlugin.dll",
+        "McpPlugin.Common.dll",
+        "R3.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.ProBuilder.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.ProBuilder.Tests.asmdef
@@ -3,15 +3,25 @@
     "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",
-        "com.IvanMurzak.Unity.MCP.ProBuilder.Runtime",
-        "com.IvanMurzak.Unity.MCP.Runtime"
+        "com.IvanMurzak.Unity.MCP.Runtime",
+        "com.IvanMurzak.Unity.MCP.Runtime.Tests",
+        "com.IvanMurzak.Unity.MCP.TestFiles",
+        "com.IvanMurzak.Unity.MCP.ProBuilder.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "System.Text.Json.dll",
+        "Microsoft.Extensions.Logging.Abstractions.dll",
+        "Microsoft.AspNetCore.SignalR.Client.dll",
+        "Microsoft.AspNetCore.SignalR.Client.Core.dll",
+        "ReflectorNet.dll",
+        "McpPlugin.dll",
+        "McpPlugin.Common.dll",
+        "R3.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Unity-Package/Packages/packages-lock.json
+++ b/Unity-Package/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.28.0",
+      "version": "0.35.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -49,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
This pull request updates dependencies and improves the configuration for both editor and runtime test assemblies in the Unity MCP ProBuilder project. The main changes include updating package versions, expanding assembly references, and adding new precompiled references to support additional functionality in tests.

**Dependency and package updates:**

* Updated the `com.ivanmurzak.unity.mcp` package from version `0.28.0` to `0.35.0` in `packages-lock.json`, bringing in the latest features and fixes.
* Updated the `com.unity.settings-manager` package from version `2.0.1` to `2.1.0` in `packages-lock.json`.

**Test assembly reference improvements:**

* Added new references to test assemblies in both `com.IvanMurzak.Unity.MCP.ProBuilder.Editor.Tests.asmdef` and `com.IvanMurzak.Unity.MCP.ProBuilder.Tests.asmdef`, including `com.IvanMurzak.Unity.MCP.Editor.Tests`, `com.IvanMurzak.Unity.MCP.Runtime.Tests`, and `com.IvanMurzak.Unity.MCP.TestFiles`, to enable more comprehensive testing. [[1]](diffhunk://#diff-08a5ceb312fdffa28da0bcc5e745cae5a166ce3522dcdd12456645d3bf1bffc3L7-R12) [[2]](diffhunk://#diff-c653555f417a8a4fc573edc19c307a1fff0bc19e3863730e9b1e4925d5508927L6-R24)

**Precompiled reference enhancements:**

* Expanded the list of precompiled references for both editor and runtime test assemblies to include additional DLLs such as `System.Text.Json.dll`, `Microsoft.Extensions.Logging.Abstractions.dll`, `Microsoft.AspNetCore.SignalR.Client.dll`, `ReflectorNet.dll`, `McpPlugin.dll`, `McpPlugin.Common.dll`, and `R3.dll`, supporting more advanced testing scenarios and dependencies. [[1]](diffhunk://#diff-08a5ceb312fdffa28da0bcc5e745cae5a166ce3522dcdd12456645d3bf1bffc3L19-R29) [[2]](diffhunk://#diff-c653555f417a8a4fc573edc19c307a1fff0bc19e3863730e9b1e4925d5508927L6-R24)