### PR TITLE
feat: add MCP tool hint annotations to ProBuilder tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
@@ -30,7 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [McpPluginTool
         (
             ProBuilderDeleteFacesToolId,
-            Title = "Delete ProBuilder faces"
+            Title = "Delete ProBuilder faces",
+            DestructiveHint = true
         )]
         [Description(@"Deletes selected faces from a ProBuilder mesh.
 You can select faces by index OR by direction (semantic selection).

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
@@ -29,7 +29,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [McpPluginTool
         (
             ProBuilderGetMeshInfoToolId,
-            Title = "Get ProBuilder mesh information"
+            Title = "Get ProBuilder mesh information",
+            ReadOnlyHint = true,
+            IdempotentHint = true
         )]
         [Description(@"Retrieves information about a ProBuilder mesh including faces, vertices, and edges.
 Use detail=""summary"" for a token-efficient overview showing face directions.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
@@ -32,7 +32,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [McpPluginTool
         (
             ProBuilderMergeObjectsToolId,
-            Title = "Merge multiple ProBuilder meshes into one"
+            Title = "Merge multiple ProBuilder meshes into one",
+            DestructiveHint = true
         )]
         [Description(@"Combines multiple ProBuilder meshes into a single mesh.
 Useful for optimizing draw calls or creating a unified object from parts.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
@@ -31,7 +31,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [McpPluginTool
         (
             ProBuilderSetFaceMaterialToolId,
-            Title = "Set material on ProBuilder faces"
+            Title = "Set material on ProBuilder faces",
+            IdempotentHint = true
         )]
         [Description(@"Assigns a material to specific faces of a ProBuilder mesh.
 You can select faces by index OR by direction (semantic selection).

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
@@ -43,7 +43,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [McpPluginTool
         (
             ProBuilderSetPivotToolId,
-            Title = "Set the pivot point of a ProBuilder mesh"
+            Title = "Set the pivot point of a ProBuilder mesh",
+            IdempotentHint = true
         )]
         [Description(@"Changes the pivot (origin) point of a ProBuilder mesh.
 The mesh geometry is adjusted so the pivot moves without changing the visual position.


### PR DESCRIPTION
Add ReadOnlyHint, DestructiveHint, and IdempotentHint annotations to ProBuilder MCP tools based on their behavior:
- GetMeshInfo: ReadOnlyHint=true, IdempotentHint=true (pure query tool)
- DeleteFaces: DestructiveHint=true (permanently removes mesh geometry)
- MergeObjects: DestructiveHint=true (can delete source GameObjects)
- SetPivot: IdempotentHint=true (setting same pivot location is idempotent)
- SetFaceMaterial: IdempotentHint=true (applying same material is idempotent)

Closes #11

Generated with [Claude Code](https://claude.ai/code)