### PR TITLE
fix(deps): adopt AIGD namespace for Unity-MCP 0.68.0

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
@@ -16,7 +16,7 @@ using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
@@ -15,7 +15,7 @@ using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
@@ -16,7 +16,7 @@ using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEngine;
 using UnityEngine.ProBuilder;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
@@ -16,7 +16,7 @@ using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine.ProBuilder;


### PR DESCRIPTION
## Summary

Unity-MCP 0.68.0 renamed the `com.IvanMurzak.Unity.MCP.Runtime.Data` namespace to `AIGD` ([Unity-MCP#704](https://github.com/IvanMurzak/Unity-MCP/pull/704)). This extension's CI broke on the 0.68.0 bump with CS0234 errors that cascaded into CS0246 failures for `GameObjectRef`.

This PR replaces the `using` directive in all 13 ProBuilder tool files. There are no fully-qualified references to clean up.

Failing run that motivated this fix: https://github.com/IvanMurzak/Unity-AI-ProBuilder/actions/runs/25261012942

## Test plan

- [x] All 13 affected files updated to `using AIGD;`
- [x] No remaining references to `com.IvanMurzak.Unity.MCP.Runtime.Data` in the package
- [x] Bundled NuGet folders confirm McpPlugin 6.1.2 / ReflectorNet 5.1.1 (matches CI expectations — no path drift)
- [ ] CI green on `release.yml` (build-unity-installer + test matrix)