### PR TITLE
feat(skills): add SkillDescription/SkillBody to ProBuilder tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bevel.cs
@@ -37,6 +37,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Bevel (chamfer) selected edges of a `ProBuilderMesh`, replacing each sharp edge " +
+            "with an angled face. Identify edges by their `[vertexA, vertexB]` index pairs — use " +
+            "'" + ProBuilderGetMeshInfoToolId + "' to discover them. `amount` is clamped to (0, 1).")]
+        [McpPluginSkillBody("Bevel (chamfer) selected edges of a `ProBuilderMesh`, replacing each sharp edge with " +
+            "an angled face for a smoother appearance. Use '" + ProBuilderGetMeshInfoToolId + "' first to " +
+            "discover edges by their vertex pairs.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `edges` — array of edge definitions; each edge is `[vertexA, vertexB]`. Example: " +
+            "`[[0,1], [2,3]]` bevels two edges.\n" +
+            "- `amount` — bevel strength in the range (0, 1). `0.001` is barely visible, `0.999` reaches face " +
+            "center. Recommended `0.05`–`0.2`. Internally clamped.\n\n" +
+            "## Behavior\n\n" +
+            "Vertex indices are validated against `vertexCount`. After `BevelEdges` runs, the mesh is rebuilt " +
+            "(`ToMesh` → `Refresh`), the `ProBuilderMesh` and GameObject are marked dirty, and Editor windows " +
+            "repaint. Returns the number of edges processed, the clamped amount, and post-op face/vertex/edge " +
+            "counts. The whole call runs on the Unity main thread.")]
         [Description(@"Bevels selected edges of a ProBuilder mesh, creating chamfered corners.
 Use ProBuilder_GetMeshInfo to identify edges by their vertex pairs.
 Beveling replaces sharp edges with angled faces for a smoother appearance.")]

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Bridge.cs
@@ -36,6 +36,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Create a single new face that bridges two existing edges of a `ProBuilderMesh`. " +
+            "Useful for connecting separate parts of geometry or filling gaps. Pair with " +
+            "'" + ProBuilderGetMeshInfoToolId + "' to discover valid edges.")]
+        [McpPluginSkillBody("Create a single new face that bridges two existing edges of a `ProBuilderMesh`. " +
+            "Useful for connecting separate parts of geometry or filling gaps between disjoint sections. Pair " +
+            "with '" + ProBuilderGetMeshInfoToolId + "' to discover valid edges first.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `edgeA` — first edge as `[vertexA, vertexB]`.\n" +
+            "- `edgeB` — second edge as `[vertexA, vertexB]`.\n" +
+            "- `allowNonManifold` — when `true`, permits the bridge to share an edge with more than two faces. " +
+            "Defaults to `false`.\n\n" +
+            "## Example\n\n" +
+            "`edgeA=[0,1]`, `edgeB=[4,5]` creates a quad face between the two edges.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), dirty-flagged, and the Editor repaints. Returns the " +
+            "index of the new face, before/after face counts, and post-op vertex/edge counts. Throws when the " +
+            "bridge cannot be formed (e.g., edges already connected or non-manifold check blocked it). The whole " +
+            "call runs on the Unity main thread.")]
         [Description(@"Creates a new face connecting two edges.
 Useful for connecting separate parts of geometry or filling gaps.
 

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.ConnectEdges.cs
@@ -38,6 +38,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Insert new edges connecting the midpoints of selected edges within faces of a " +
+            "`ProBuilderMesh` — adds edge loops and extra geometry detail. Supply either `edges` (explicit list) " +
+            "or `faceDirection` (semantic selection); exactly one is required.")]
+        [McpPluginSkillBody("Insert new edges connecting the midpoints of selected edges within faces of a " +
+            "`ProBuilderMesh`. When a face has more than two edges to connect, a center vertex is added. " +
+            "Useful for creating new edge loops and adding geometry detail.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `edges` — explicit list of edges to connect, each as `[vertexA, vertexB]`. Use " +
+            "'" + ProBuilderGetMeshInfoToolId + "' to discover valid indices.\n" +
+            "- `faceDirection` — semantic alternative: connects all edges of faces pointing this direction " +
+            "(`Up`, `Down`, `Left`, `Right`, `Forward`, `Back`). Exactly one of `edges` / `faceDirection` is " +
+            "required.\n\n" +
+            "## Examples\n\n" +
+            "- Connect opposite edges of the top face: `faceDirection=\"up\"`.\n" +
+            "- Connect specific edges: `edges=[[0,1], [2,3]]`.")]
         [Description(@"Inserts new edges connecting the midpoints of selected edges within faces.
 If a face has more than 2 edges to connect, a center vertex is added.
 This is useful for creating new edge loops and adding geometry detail.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.CreateShape.cs
@@ -36,6 +36,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Create a new editable `ProBuilderMesh` GameObject in the active scene from a " +
+            "`ShapeType` primitive (Cube, Cylinder, Sphere, Plane, Prism, Cone, Stair, etc.). Optionally set " +
+            "name, parent, transform, size, and world/local space.")]
+        [McpPluginSkillBody("Create a new editable `ProBuilderMesh` GameObject in the active scene. ProBuilder " +
+            "shapes are editable 3D meshes that can be further modified with the rest of the ProBuilder tools " +
+            "(extrude, bevel, subdivide, etc.).\n\n" +
+            "## Inputs\n\n" +
+            "- `shapeType` — `ShapeType` enum (Cube, Cylinder, Sphere, Plane, Prism, Cone, Stair, Door, " +
+            "Pipe, Arch, Sprite, Torus, etc.).\n" +
+            "- `name` — optional GameObject name.\n" +
+            "- `parentGameObjectRef` — optional parent; root of the scene when omitted.\n" +
+            "- `position`, `rotation`, `scale` — optional `Vector3` transform values. Rotation is euler degrees. " +
+            "Defaults: zero / zero / one.\n" +
+            "- `size` — `Vector3` width/height/depth of the generated shape. Default `(1, 1, 1)`.\n" +
+            "- `isLocalSpace` — when `true`, position/rotation/scale are interpreted in the parent's local " +
+            "space; otherwise world space.\n\n" +
+            "## Behavior\n\n" +
+            "Uses `ShapeGenerator.CreateShape` with `PivotLocation.Center`, applies the transform values, " +
+            "rebuilds the mesh, marks dirty, and repaints the Editor. The whole call runs on the Unity main " +
+            "thread.")]
         [Description(@"Creates a new ProBuilder mesh shape in the scene. ProBuilder shapes are editable 3D meshes
 that can be modified using other ProBuilder tools like extrusion, beveling, etc.")]
         public CreateShapeResponse CreateShape

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.DeleteFaces.cs
@@ -36,6 +36,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Delete selected faces from a `ProBuilderMesh`, creating holes or removing " +
+            "geometry. Supply either `faceIndices` (explicit list) or `faceDirection` (semantic selection); " +
+            "exactly one is required.")]
+        [McpPluginSkillBody("Delete selected faces from a `ProBuilderMesh`, creating holes or removing geometry " +
+            "entirely. Faces can be selected explicitly by index or semantically by direction.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `faceIndices` — explicit array of face indices to delete. Use " +
+            "'" + ProBuilderGetMeshInfoToolId + "' to discover valid indices.\n" +
+            "- `faceDirection` — semantic alternative (`Up`, `Down`, `Left`, `Right`, `Forward`, `Back`). " +
+            "Exactly one of `faceIndices` / `faceDirection` is required.\n\n" +
+            "## Examples\n\n" +
+            "- Delete the bottom face: `faceDirection=\"down\"`.\n" +
+            "- Delete specific faces: `faceIndices=[0, 2, 4]`.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), the `ProBuilderMesh` and GameObject are marked dirty, " +
+            "and Editor windows repaint. The whole call runs on the Unity main thread.")]
         [Description(@"Deletes selected faces from a ProBuilder mesh.
 You can select faces by index OR by direction (semantic selection).
 Deleting faces creates holes in the mesh or removes geometry entirely.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.Extrude.cs
@@ -37,6 +37,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Extrude selected faces of a `ProBuilderMesh` along their normals, creating new " +
+            "geometry. Supply either `faceIndices` (explicit) or `faceDirection` (semantic); exactly one is " +
+            "required. Positive `distance` extrudes outward, negative inward.")]
+        [McpPluginSkillBody("Extrude selected faces of a `ProBuilderMesh` along their normals, creating new " +
+            "geometry by pushing faces outward (positive distance) or inward (negative distance). Faces can be " +
+            "selected explicitly by index or semantically by direction.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `faceIndices` — explicit array of face indices to extrude.\n" +
+            "- `faceDirection` — semantic alternative (`Up`, `Down`, `Left`, `Right`, `Forward`, `Back`). " +
+            "Exactly one of `faceIndices` / `faceDirection` is required.\n" +
+            "- `distance` — extrusion distance. Positive = outward, negative = inward. Default `0.5`.\n" +
+            "- `extrudeMethod` — `IndividualFaces` (each face extrudes independently), `FaceNormal` (faces " +
+            "extrude as a group along the averaged normal — the default), or `VertexNormal` (vertices move " +
+            "along their normals).\n\n" +
+            "## Examples\n\n" +
+            "- Extrude the top face up by 1 unit: `faceDirection=\"up\"`, `distance=1`.\n" +
+            "- Extrude specific faces: `faceIndices=[0, 2, 4]`.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), dirty-flagged, and the Editor repaints. The whole call " +
+            "runs on the Unity main thread.")]
         [Description(@"Extrudes selected faces of a ProBuilder mesh along their normals.
 You can select faces by index OR by direction (semantic selection).
 Extrusion creates new geometry by pushing faces outward (or inward with negative distance).

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.FlipNormals.cs
@@ -36,6 +36,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Reverse the normal direction of selected faces in a `ProBuilderMesh`, flipping " +
+            "them inside-out. Useful for creating interior spaces (a room from the inside of a cube) or fixing " +
+            "inverted faces. Defaults to all faces when no selection is supplied.")]
+        [McpPluginSkillBody("Reverse the normal direction of selected faces in a `ProBuilderMesh`, flipping them " +
+            "inside-out. Useful for creating interior spaces (a room from the inside of a cube) or fixing " +
+            "inverted faces produced by other operations.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `faceIndices` — optional explicit list of face indices to flip.\n" +
+            "- `faceDirection` — optional semantic alternative (`Up`, `Down`, `Left`, `Right`, `Forward`, " +
+            "`Back`).\n\n" +
+            "When both are omitted, **every face** is flipped.\n\n" +
+            "## Examples\n\n" +
+            "- Flip all faces: leave both `faceIndices` and `faceDirection` empty.\n" +
+            "- Flip top face only: `faceDirection=Up`.\n" +
+            "- Flip specific faces: `faceIndices=[0, 2, 4]`.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), dirty-flagged, and the Editor repaints. The whole call " +
+            "runs on the Unity main thread.")]
         [Description(@"Reverses the normal direction of selected faces, flipping them inside-out.
 Useful for creating interior spaces or fixing inverted faces.
 

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.GetMeshInfo.cs
@@ -35,6 +35,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Inspect a `ProBuilderMesh` — face/vertex/edge counts plus optional face-by-face " +
+            "detail. Use `detail=\"summary\"` for a token-efficient overview, `detail=\"full\"` for detailed " +
+            "face data. Often skippable when other tools accept `faceDirection` semantic selection.")]
+        [McpPluginSkillBody("Inspect a `ProBuilderMesh` — totals (face/vertex/edge counts) plus optional " +
+            "face-by-face detail (per-face vertex positions, edges, semantic direction). The other ProBuilder " +
+            "tools accept `faceDirection` (semantic selection like `\"up\"`, `\"down\"`) — when that suffices, " +
+            "you can skip this call entirely.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `detail` — `Summary` (default, cheap overview with face directions) or `Full` (per-face data).\n" +
+            "- `includeVertexPositions` — `Full` only. Include each face's vertex positions in the response.\n" +
+            "- `includeEdges` — `Full` only. Include each face's edges. Default `true`.\n" +
+            "- `maxFacesToShow` — `Full` only. Cap on face-detail entries (default `20`; pass `-1` for all). " +
+            "Keeps the response small for high-face meshes.\n\n" +
+            "## Tip\n\n" +
+            "With semantic face selection (`faceDirection`) available on Extrude / DeleteFaces / SetFaceMaterial " +
+            "and friends, you often don't need this tool — just pass `faceDirection=\"up\"` etc. directly.")]
         [Description(@"Retrieves information about a ProBuilder mesh including faces, vertices, and edges.
 Use detail=""summary"" for a token-efficient overview showing face directions.
 Use detail=""full"" for detailed face-by-face information.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.MergeObjects.cs
@@ -39,6 +39,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Combine multiple `ProBuilderMesh` GameObjects into one merged mesh. The first " +
+            "GameObject in the list becomes the merge target. Source GameObjects are deleted by default. " +
+            "Useful for optimizing draw calls and unifying composite props.")]
+        [McpPluginSkillBody("Combine multiple `ProBuilderMesh` GameObjects into a single merged mesh. The first " +
+            "GameObject in `gameObjectRefs` becomes the merge target — subsequent meshes are absorbed into it. " +
+            "Useful for optimizing draw calls or creating a unified object from parts.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRefs` — array of GameObject references (≥2). Each must carry a `ProBuilderMesh` " +
+            "component. The first reference is the merge target.\n" +
+            "- `deleteSourceObjects` — when `true` (default), delete the non-target source GameObjects after " +
+            "merging. Set `false` to keep them in the scene.\n\n" +
+            "## Example\n\n" +
+            "Merge a table assembled from four leg meshes and a top into a single GameObject for shipping.\n\n" +
+            "## Behavior\n\n" +
+            "All meshes are rebuilt (`ToMesh` → `Refresh`), the resulting GameObject is marked dirty, and the " +
+            "Editor repaints. The whole call runs on the Unity main thread.")]
         [Description(@"Combines multiple ProBuilder meshes into a single mesh.
 Useful for optimizing draw calls or creating a unified object from parts.
 The first mesh in the list becomes the target that others merge into.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.PolyShape.cs
@@ -38,6 +38,28 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Create a 3D `ProBuilderMesh` from a 2D polygon outline (x,z points) extruded " +
+            "upward by `height`. Perfect for floor plans, room layouts, terrain patches, walls, platforms — any " +
+            "shape definable by a 2D outline. Requires ≥3 points.")]
+        [McpPluginSkillBody("Create a 3D `ProBuilderMesh` from a 2D polygon outline (x,z points) extruded upward " +
+            "by `height`. Perfect for:\n\n" +
+            "- Floor plans and room layouts.\n" +
+            "- Custom terrain patches.\n" +
+            "- Architectural elements (walls, platforms).\n" +
+            "- Any shape that can be defined by a 2D outline.\n\n" +
+            "## Inputs\n\n" +
+            "- `points` — array of 2D points as `[x, z]`. Minimum 3 points; should be in clockwise or " +
+            "counter-clockwise order.\n" +
+            "- `height` — extrusion height upward (Y axis). Default `1`.\n" +
+            "- `name` — optional GameObject name.\n" +
+            "- `parentGameObjectRef` — optional parent; root of the scene when omitted.\n" +
+            "- `position`, `rotation` — optional `Vector3` transform values (rotation in euler degrees).\n" +
+            "- `flipNormals` — when `true`, flip the resulting face normals so the shape points inward.\n" +
+            "- `isLocalSpace` — when `true`, position/rotation are interpreted in the parent's local space.\n\n" +
+            "## Examples\n\n" +
+            "- Rectangle: `points=[[0,0], [4,0], [4,3], [0,3]]`, `height=2.5`.\n" +
+            "- L-shape: `points=[[0,0], [3,0], [3,2], [1,2], [1,3], [0,3]]`, `height=3`.\n" +
+            "- Triangle: `points=[[0,0], [2,0], [1,1.7]]`, `height=1`.")]
         [Description(@"Creates a 3D mesh from a 2D polygon outline. Perfect for:
 - Floor plans and room layouts
 - Custom terrain patches

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetFaceMaterial.cs
@@ -37,6 +37,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Assign a material to specific faces of a `ProBuilderMesh`, enabling " +
+            "multi-material meshes (e.g., grass on top, dirt on sides). Supply either `faceIndices` (explicit) " +
+            "or `faceDirection` (semantic); exactly one is required.")]
+        [McpPluginSkillBody("Assign a material to specific faces of a `ProBuilderMesh`, enabling multi-material " +
+            "meshes where different faces have different materials (e.g., grass on top, dirt on the sides).\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `materialPath` — project path to the material asset (e.g., `Assets/Materials/Grass.mat`) or a " +
+            "bare material name. Required.\n" +
+            "- `faceIndices` — explicit array of face indices.\n" +
+            "- `faceDirection` — semantic alternative (`Up`, `Down`, `Left`, `Right`, `Forward`, `Back`). " +
+            "Exactly one of `faceIndices` / `faceDirection` is required.\n\n" +
+            "## Examples\n\n" +
+            "- Set material on the top face: `faceDirection=\"up\"`.\n" +
+            "- Set material on specific faces: `faceIndices=[0, 2, 4]`.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), dirty-flagged, and the Editor repaints. The whole call " +
+            "runs on the Unity main thread.")]
         [Description(@"Assigns a material to specific faces of a ProBuilder mesh.
 You can select faces by index OR by direction (semantic selection).
 This enables multi-material meshes where different faces have different materials.

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SetPivot.cs
@@ -50,6 +50,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Move the pivot (origin) of a `ProBuilderMesh` without shifting the visible " +
+            "geometry. Choose `Center` (mesh bounds), `FirstVertex`, or `Custom` (world-space position). The " +
+            "mesh data is rebaked so the visual position stays fixed.")]
+        [McpPluginSkillBody("Move the pivot (origin) of a `ProBuilderMesh` without shifting the visible " +
+            "geometry. The mesh data is rebaked so the visual position stays fixed while the GameObject's " +
+            "transform origin moves to the new pivot.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `pivotLocation` — `MeshPivotLocation` enum: `Center` (mesh bounds center), `FirstVertex`, or " +
+            "`Custom`.\n" +
+            "- `customPosition` — required when `pivotLocation = Custom`. World-space pivot position.\n\n" +
+            "## Examples\n\n" +
+            "- Center the pivot: `pivotLocation=Center`.\n" +
+            "- Set pivot to first vertex: `pivotLocation=FirstVertex`.\n" +
+            "- Set custom pivot: `pivotLocation=Custom`, `customPosition=(0, 0, 0)`.\n\n" +
+            "## Behavior\n\n" +
+            "The mesh is rebuilt (`ToMesh` → `Refresh`), dirty-flagged, and the Editor repaints. The whole call " +
+            "runs on the Unity main thread.")]
         [Description(@"Changes the pivot (origin) point of a ProBuilder mesh.
 The mesh geometry is adjusted so the pivot moves without changing the visual position.
 

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ProBuilder.SubdivideEdges.cs
@@ -38,6 +38,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Insert new vertices on selected edges of a `ProBuilderMesh`, splitting each " +
+            "edge into smaller segments. Supply either `edges` (explicit list) or `faceDirection` (subdivides " +
+            "all edges of faces facing that direction); exactly one is required.")]
+        [McpPluginSkillBody("Insert new vertices on selected edges of a `ProBuilderMesh`, subdividing each into " +
+            "smaller segments. Useful for adding detail to specific edges for further manipulation (extrude, " +
+            "bevel, etc.).\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ProBuilderMesh` component.\n" +
+            "- `edges` — explicit list of edges to subdivide, each as `[vertexA, vertexB]`. Use " +
+            "'" + ProBuilderGetMeshInfoToolId + "' to discover valid edges.\n" +
+            "- `faceDirection` — semantic alternative: subdivides all edges of faces pointing this direction " +
+            "(`Up`, `Down`, `Left`, `Right`, `Forward`, `Back`). Exactly one of `edges` / `faceDirection` is " +
+            "required.\n" +
+            "- `subdivisions` — number of subdivisions per edge. `1` splits each edge in half, `2` into thirds, " +
+            "and so on. Default `1`.\n\n" +
+            "## Examples\n\n" +
+            "- Subdivide all edges of the top face: `faceDirection=\"up\"`, `subdivisions=2`.\n" +
+            "- Subdivide specific edges: `edges=[[0,1], [2,3]]`, `subdivisions=1`.")]
         [Description(@"Inserts new vertices on edges, subdividing them into smaller segments.
 Useful for adding detail to specific edges for further manipulation.
 

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -16,7 +16,7 @@
     "unity": "2022.3",
     "description": "MCP Tools for ProBuilder - Enhance your Unity projects with AI-powered ProBuilder tools using the MCP framework.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.72.1",
+        "com.ivanmurzak.unity.mcp": "0.72.2",
         "com.unity.probuilder": "5.2.4"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "0.72.1",
+    "com.ivanmurzak.unity.mcp": "0.72.2",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.probuilder": "5.2.4",
     "com.unity.test-framework": "1.1.33",


### PR DESCRIPTION
## Summary

Follow-on to Unity-MCP [PR #758](https://github.com/IvanMurzak/Unity-MCP/pull/758) — extends the `[McpPluginSkillDescription]` / `[McpPluginSkillBody]` coverage from the core Unity-MCP plugin to this extension. All 13 tool methods exposed by this package now carry both attributes.

## Changes

- Bumped `com.ivanmurzak.unity.mcp` dependency from `0.72.1` → `0.72.2` in `Unity-Package/Assets/root/package.json` and `Unity-Package/Packages/manifest.json`. The new attributes were introduced in `0.72.2`.
- Decorated each tool with `[McpPluginSkillDescription]` (concise summary suitable for the SKILL.md YAML front-matter, well under the 1024-char cap) and `[McpPluginSkillBody]` (long-form markdown with `## Inputs`, `## Examples`, `## Behavior`, `## Tip` sections as appropriate):
  - `ProBuilder.Bevel.cs` — `probuilder-bevel`
  - `ProBuilder.Bridge.cs` — `probuilder-bridge`
  - `ProBuilder.ConnectEdges.cs` — `probuilder-connect-edges`
  - `ProBuilder.CreateShape.cs` — `probuilder-create-shape`
  - `ProBuilder.DeleteFaces.cs` — `probuilder-delete-faces`
  - `ProBuilder.Extrude.cs` — `probuilder-extrude`
  - `ProBuilder.FlipNormals.cs` — `probuilder-flip-normals`
  - `ProBuilder.GetMeshInfo.cs` — `probuilder-get-mesh-info`
  - `ProBuilder.MergeObjects.cs` — `probuilder-merge-objects`
  - `ProBuilder.PolyShape.cs` — `probuilder-create-poly-shape`
  - `ProBuilder.SetFaceMaterial.cs` — `probuilder-set-face-material`
  - `ProBuilder.SetPivot.cs` — `probuilder-set-pivot`
  - `ProBuilder.SubdivideEdges.cs` — `probuilder-subdivide-edges`
- `[Description]` payloads are left **byte-identical** to `main`, so the MCP `tools/list` wire response is unchanged.

## Out of scope

- The generated `Unity-Package/.claude/skills/probuilder-*/SKILL.md` files are intentionally left untouched in this PR. They should be regenerated by running the `unity-skill-generate` MCP tool inside Unity and committed as a follow-up (same round-trip pattern as Unity-MCP PR #758 commit `57334844`).

## Verification

- Static review confirms both new attributes are correctly applied to every `[McpPluginTool]` method and the `[Description]` strings are byte-identical to `main`.
- A reviewer with Unity open should run `unity-skill-generate` to confirm the regenerated SKILL.md files include the new `description:` YAML field and body markdown.

Refs IvanMurzak/Unity-MCP#729, IvanMurzak/Unity-MCP#758

🤖 Generated with [Claude Code](https://claude.com/claude-code)